### PR TITLE
Include FxUX banner from GitHub Pages

### DIFF
--- a/app/embed.html
+++ b/app/embed.html
@@ -10,7 +10,7 @@
         <meta name="viewport" content="width=device-width">
         <link rel="shortcut icon" href="/favicon.ico">
         <link href='http://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700,300italic' rel='stylesheet' type='text/css'>
-        <script type="text/javascript" src="https://raw.githubusercontent.com/FirefoxUX/SharedBanner/master/dist/fxux-banner.min.js"></script>
+        <script type="text/javascript" src="https://firefoxux.github.io/SharedBanner/fxux-banner.min.js"></script>
         <!-- Place favicon.ico and apple-touch-icon.png in the root directory -->
         <!-- build:css styles/vendor.css -->
         <!-- bower:css -->

--- a/app/index.html
+++ b/app/index.html
@@ -10,7 +10,7 @@
         <meta name="viewport" content="width=device-width">
         <link rel="shortcut icon" href="/favicon.ico">
         <link href='http://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700,300italic' rel='stylesheet' type='text/css'>
-        <script type="text/javascript" src="https://raw.githubusercontent.com/FirefoxUX/SharedBanner/master/dist/fxux-banner.min.js"></script>
+        <script type="text/javascript" src="https://firefoxux.github.io/SharedBanner/fxux-banner.min.js"></script>
         <!-- Place favicon.ico and apple-touch-icon.png in the root directory -->
         <!-- build:css styles/vendor.css -->
         <!-- bower:css -->


### PR DESCRIPTION
This was broken because raw.githubusercontent.com serves things with
`text/plain`, which caused browsers to ignore them.